### PR TITLE
Remove reference to IETF from RFCs index.md

### DIFF
--- a/development/rfcs/index.md
+++ b/development/rfcs/index.md
@@ -10,8 +10,7 @@ keywords: PyWPS, community, RFCs
 An RFC is a memorandum describing methods, behaviors, research, or innovations
 applicable to the working of the Internet and Internet-connected systems. It is
 submitted either for peer review or simply to convey new concepts, information,
-or (occasionally) engineering humor. The IETF adopts some of the proposals
-published as RFCs as Internet standards.
+or (occasionally) engineering humor.
 
 An RFC describes a major change in the technological underpinnings of PyWPS,
 major additions to functionality, or changes in the direction of the project.


### PR DESCRIPTION
Removes the reference to IETF from the Request For Comments (RFC) index page. The next paragraph describes clearly how the RFCs relate to the project.